### PR TITLE
Build documentation conditionally

### DIFF
--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -1,4 +1,16 @@
-SUBDIRS = . libinfinity libinftext libinfgtk libinftextgtk libinfinoted-plugin-manager
+SUBDIRS = . libinfinity libinftext
+
+if WITH_INFGTK
+SUBDIRS += libinfgtk
+endif
+
+if WITH_INFTEXTGTK
+SUBDIRS += libinftextgtk
+endif
+
+if WITH_INFINOTED
+SUBDIRS += libinfinoted-plugin-manager
+endif
 
 # Note that nodist doesn't work here actually because gtk-doc pulls them
 # in anyway (see content_files in a subdirectory's Makefile.am)


### PR DESCRIPTION
Building documentation for disabled libraries fails with the
following error:

```
libtool: link: cannot find the library `../../../libinfgtk/libinfgtk-0.6.la' or unhandled argument `../../../libinfgtk/libinfgtk-0.6.la'
Linking of scanner failed:
Makefile:609: recipe for target 'scan-build.stamp' failed
```
