### PR TITLE
Initialize root_directory setting with absolute path

### DIFF
--- a/libinfinity/server/infd-filesystem-storage.c
+++ b/libinfinity/server/infd-filesystem-storage.c
@@ -127,6 +127,14 @@ infd_filesystem_storage_set_root_directory(InfdFilesystemStorage* storage,
   }
   else
   {
+    if (!g_path_is_absolute(converted))
+    {
+      gchar* cwd = g_get_current_dir();
+      gchar* full_path = g_build_filename(cwd, converted, NULL);
+      g_free(cwd);
+      g_free(converted);
+      converted = full_path;
+    }
     if(!inf_file_util_create_directory(converted, 0755, &error))
     {
       g_warning(


### PR DESCRIPTION
When starting infinoted twice like this

> `$ ./infinoted-0.7 --root-directory=data --security-policy=no-tls`

a warning is emitted and infinoted becomes unusable:

> Wed 16 Mar 2016 06:12:15 PM CET] WARNING: Failed to read the ACL for the root node: The pathname 'data/global-acl.xml' is not an absolute path
> In order not to compromise security all permissions have been revoked for all users. The infinote server is likely not very usable in this configuration, so please check the storage system, fix the problem and re-start the server.

The ACL file `global-acl.xml` which is created during first invocation cannot be read during second invocation.  The cause seems to be the function `infd_filesystem_storage_storage_read_acl()`.

First, `infd_filesystem_storage_get_acl_path() -> infd_filesystem_storage_get_path()` is called and it should assure (according to the documentation) to always return an absolute path to said file. However, it only returns an absolute path if the "root-directory" setting was already absolute. Then, `infd_filesystem_storage_read_xml_file_impl() -> g_filename_to_uri()` is called which expects an absolute path and fails otherwise.

The PR should ensure that `priv->root_directory` is always initialized with an absolute path. Thus, both relative and absolute settings of `--root-directory` should now be handled correctly.