### PR TITLE
Add missing null terminator to inf_browser_status_values

### DIFF
--- a/libinfinity/common/inf-browser.c
+++ b/libinfinity/common/inf-browser.c
@@ -52,6 +52,10 @@ static const GEnumValue inf_browser_status_values[] = {
     INF_BROWSER_OPEN,
     "INF_BROWSER_OPEN",
     "open"
+  }, {
+    0,
+    NULL,
+    NULL
   }
 };
 


### PR DESCRIPTION
This fixes a segmentation fault when running g-ir-scanner on macOS.