### PR TITLE
Include <stdio.h> for printf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,6 +105,7 @@ AC_TRY_COMPILE([#include <dirent.h>
 AC_MSG_CHECKING(for O_NOFOLLOW)
 AC_TRY_COMPILE([#include <sys/types.h>
                 #include <sys/stat.h>
+                #include <stdio.h>
                 #include <fcntl.h> ],
                [ printf("%d\n", O_NOFOLLOW); ],
                [ AC_MSG_RESULT(yes)


### PR DESCRIPTION
Without this, the test fails when using `-Werror=implicit-function-declaration` or compilers that default to that behavior, including Apple clang 1200 and later and llvm.org clang 16 and later.